### PR TITLE
Issue 36592: Move/Copy file fails if path exceeds 255 chars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.upplication</groupId>
 	<artifactId>s3fs</artifactId>
 	<packaging>jar</packaging>
-	<version>2.2.2.3</version>
+	<version>2.2.2.5</version>
 	<name>s3fs</name>
 	<description>S3 filesystem provider for Java 7</description>
 	<url>https://github.com/Upplication/Amazon-S3-FileSystem-NIO2</url>

--- a/src/main/java/com/upplication/s3fs/S3SeekableByteChannel.java
+++ b/src/main/java/com/upplication/s3fs/S3SeekableByteChannel.java
@@ -49,7 +49,7 @@ public class S3SeekableByteChannel implements SeekableByteChannel {
                 throw new NoSuchFileException(format("target not exists: %s", path));
         }
 
-        tempFile = Files.createTempFile("temp-s3-", key.replaceAll("/", "_"));
+        tempFile = Files.createTempFile("temp-s3-", String.valueOf(System.nanoTime()));
         boolean removeTempFile = true;
         try {
             if (exists) {


### PR DESCRIPTION
Change to generate shorter tempfile name, using System.nanoTime()